### PR TITLE
Test x4-save-miner functions and fix faction stats crash

### DIFF
--- a/x4-save-miner.py
+++ b/x4-save-miner.py
@@ -679,9 +679,9 @@ if args.factions:
         line += " |"
         for ship in ["ship_xs", "ship_s", "ship_m", "ship_l", "ship_xl"]:
             sub = ship.split('_')[1]
-            if ship in stats[faction]['ships']:
+            if "ships" in stats[faction] and ship in stats[faction]['ships']:
                 res = str(stats[faction]['ships'][ship])
-                line += (" " * (5 + len(sub) - len(res))) + res 
+                line += (" " * (5 + len(sub) - len(res))) + res
             else:
                 line += (" " * (4 + len(sub))) + "-"
         print(line)


### PR DESCRIPTION
## Summary
- run the test_save file with each option of `x4-save-miner.py`
- fix the `-f/--factions` command to avoid `KeyError` when some factions have no ships

## Testing
- `python3 -m py_compile x4-save-miner.py`
- `python3 x4-save-miner.py -f test_save/save_001.xml.gz > /tmp/output_f.txt`
- `python3 x4-save-miner.py -c XRE-902 -p test_save/save_001.xml.gz > /tmp/output_p.txt`
- `python3 x4-save-miner.py -s test_save/save_001.xml.gz <<'EOF'
exit()
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_6887f4ff8a448325b5af31281ca5c22b