### PR TITLE
Add profitable trade search

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ options:
   -q, --quiet           Suppress warnings in interactive mode
   -i INFO, --info INFO  information level [1-3]. Default is 1 (sector only)
   -f, --factions        Display faction relative strengths
+  -t [N], --trades [N]  Show the top N profitable ware trades (default 5)
   -s, --shell           Starts a python shell to interract with the XML data (read-only)
 ```
 


### PR DESCRIPTION
## Summary
- add new optional `-t/--trades` argument
- parse station trades and compute best profit opportunities
- expose `getProfitableTrades` and print results
- document new option in README

## Testing
- `python3 x4-save-miner.py -h`
- `python3 x4-save-miner.py test_save/save_001.xml.gz -t 3 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688807f4979883258c36e73e18c44888