### PR TITLE
Add optional cargo limit for trade profit search

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ options:
   -q, --quiet           Suppress warnings in interactive mode
   -i INFO, --info INFO  information level [1-3]. Default is 1 (sector only)
   -f, --factions        Display faction relative strengths
-  -t [N], --trades [N]  Show the top N profitable ware trades (default 5)
+  -t [N] [C], --trades [N] [C]  Show the top N profitable ware trades using at most C cargo (default N=5)
   -s, --shell           Starts a python shell to interract with the XML data (read-only)
 ```
 


### PR DESCRIPTION
## Summary
- allow passing `max_cargo` limit to `--trades` option
- adjust trade calculation to respect cargo limit
- document new parameter in README

## Testing
- `python3 x4-save-miner.py test_save/save_001.xml.gz -t 1 100000 | head -n 12`
- `python3 x4-save-miner.py test_save/save_001.xml.gz -t | head -n 15`
- `python3 -m py_compile x4-save-miner.py`


------
https://chatgpt.com/codex/tasks/task_e_688814e75718832592c34b616dabb671