### PR TITLE
Add player-aware trade calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ options:
   -i INFO, --info INFO  information level [1-3]. Default is 1 (sector only)
   -f, --factions        Display faction relative strengths
   -t [N] [C], --trades [N] [C]  Show the top N profitable ware trades using at most C cargo (default N=5)
-  --player              Use player location, cargo and credits when ranking trades
+  --player              Factor the player's ship location, cargo space and credits into trade ranking
   --distance            Rank trades by profit per kilometre
   -s, --shell           Starts a python shell to interract with the XML data (read-only)
 ```
+
+Using `--player` with the trades option ranks deals by profit per kilometre and automatically limits them by your ship's cargo space and available credits.
 
 The savefile can be compressed or uncompressed. It is the importing of the data that takes most of the time, once imported accessing the data is fast.
 

--- a/x4-save-miner.py
+++ b/x4-save-miner.py
@@ -879,18 +879,23 @@ if args.trades is not None:
         credits = playerMoney
     deals = getProfitableTrades(limit, max_cargo, use_distance, origin_pos, cargo_limit, credits)
     for d in deals:
-        out = f"{d['ware']}: {d['from']['station']} ({d['from']['sector_name']}) -> {d['to']['station']} ({d['to']['sector_name']}) | Qty {d['qty']} Profit/unit {int(d['profit_per'])} Total {int(d['total'])}"
+        profit_unit = f"${d['profit_per']:,.0f}"
+        total_profit = f"${d['total']:,.0f}"
+        base = f"{d['ware']}: {d['from']['station']} ({d['from']['sector_name']}) -> {d['to']['station']} ({d['to']['sector_name']})"
+        out = f"{base} | Qty {d['qty']} Profit/unit {profit_unit} Total {total_profit}"
         if use_player and 'player_dist' in d:
-            out = f"{playerLocation.get('code')} ({playerLocation.get('sector_name')}) ({int(d['player_dist']/1000)}km)-> " + \
-                  f"{d['from']['station']} ({d['from']['sector_name']}) ({int(d['sell_buy_dist']/1000)}km)-> {d['to']['station']} ({d['to']['sector_name']}) | Qty {d['qty']} Profit/unit {int(d['profit_per'])} Total {int(d['total'])}"
+            path = (
+                f"{playerLocation.get('code')} ({playerLocation.get('sector_name')}) "
+                f"({int(d['player_dist']/1000)}km)-> {d['from']['station']} "
+                f"({d['from']['sector_name']}) ({int(d['sell_buy_dist']/1000)}km)-> "
+                f"{d['to']['station']} ({d['to']['sector_name']})"
+            )
+            out = f"{d['ware']}: {path} | Qty {d['qty']} Profit/unit {profit_unit} Total {total_profit}"
         if 'distance' in d:
             if math.isfinite(d['distance']):
-                if use_player:
+                out += f" Dist {int(d['distance']/1000)}km"
+                if args.distance or use_player:
                     out += f" Score {int(d['score'])}"
-                else:
-                    out += f" Dist {int(d['distance']/1000)}km"
-                    if args.distance:
-                        out += f" Score {int(d['score'])}"
             else:
                 out += " Dist N/A"
         print(out)


### PR DESCRIPTION
## Summary
- enhance `-t` trades option to optionally consider player location, cargo, and funds
- document `player` option for trade queries

## Testing
- `python3 -m py_compile x4-save-miner.py`
- *(tests were unable to run due to script runtime; heavy XML parsing was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6888c596b21083259940504b601eb175