### PR TITLE
Add --avoid-illegal-sectors option for trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ pip3 install lxml
 
 ## Changes
 
+* 2025-05-06: Ver 1.0.9
+  - Add `--avoid-illegal-sectors` option for trades
 * 2025-05-05: Ver 1.0.8
   - Add `-f` option to show print Faction statistics
 * 2025-03-31: Ver 1.0.7
@@ -44,7 +46,7 @@ The `x4-save-miner.py` script is used to extract useful information from any sav
 
 Usage:
 ```
-usage: x4-save-miner.py [-h] [-o] [-l] [-d] [-e] [-c CODE] [-p] [-w] [-r] [-x] [-k] [-K] [-X XML] [-q] [-i INFO] [-f] [-s] savefile
+usage: x4-save-miner.py [-h] [-o] [-l] [-d] [-e] [-c CODE] [-p] [-w] [-r] [-x] [-k] [-K] [-X XML] [-q] [-i INFO] [-f] [--player] [--distance] [--avoid-illegal-sectors] [-s] savefile
 
 positional arguments:
   savefile              The savegame you want to analyse
@@ -69,6 +71,7 @@ options:
   -t [N] [C], --trades [N] [C]  Show the top N profitable ware trades using at most C cargo (default N=5)
   --player              Factor the player's ship location, cargo space and credits into trade ranking
   --distance            Rank trades by profit per kilometre
+  --avoid-illegal-sectors  Avoid trades through sectors where the ware is illegal
   -s, --shell           Starts a python shell to interract with the XML data (read-only)
 ```
 


### PR DESCRIPTION
## Summary
- allow `--avoid-illegal-sectors` when searching trades
- identify factions and sectors where contraband is illegal
- compute paths that avoid illegal sectors when possible
- document the new option and update changelog

## Testing
- `python3 -m py_compile x4-save-miner.py`
- `python3 x4-save-miner.py test_save/save_001.xml.gz -t 1`
- `python3 x4-save-miner.py test_save/save_001.xml.gz -t 1 --avoid-illegal-sectors`

------
https://chatgpt.com/codex/tasks/task_e_6888d6b57d988325a35867b9717a7db5