### PR TITLE
Implement hostile sector avoidance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ pip3 install lxml
 
 ## Changes
 
+* 2025-05-07: Ver 1.0.10
+  - Add `--avoid-hostile-sectors` option for trades
 * 2025-05-06: Ver 1.0.9
   - Add `--avoid-illegal-sectors` option for trades
 * 2025-05-05: Ver 1.0.8
@@ -46,7 +48,7 @@ The `x4-save-miner.py` script is used to extract useful information from any sav
 
 Usage:
 ```
-usage: x4-save-miner.py [-h] [-o] [-l] [-d] [-e] [-c CODE] [-p] [-w] [-r] [-x] [-k] [-K] [-X XML] [-q] [-i INFO] [-f] [--player] [--distance] [--avoid-illegal-sectors] [-s] savefile
+usage: x4-save-miner.py [-h] [-o] [-l] [-d] [-e] [-c CODE] [-p] [-w] [-r] [-x] [-k] [-K] [-X XML] [-q] [-i INFO] [-f] [--player] [--distance] [--avoid-illegal-sectors] [--avoid-hostile-sectors] [-s] savefile
 
 positional arguments:
   savefile              The savegame you want to analyse
@@ -72,6 +74,7 @@ options:
   --player              Factor the player's ship location, cargo space and credits into trade ranking
   --distance            Rank trades by profit per kilometre
   --avoid-illegal-sectors  Avoid trades through sectors where the ware is illegal
+  --avoid-hostile-sectors  Avoid trades through sectors hostile to the player
   -s, --shell           Starts a python shell to interract with the XML data (read-only)
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ options:
   -s, --shell           Starts a python shell to interract with the XML data (read-only)
 ```
 
+`--avoid-hostile-sectors` skips trades if either station is in a hostile sector
+and searches for routes that do not pass through hostile territory from the
+player's current position to the destination.  If no such route exists the trade
+is ignored. `--avoid-illegal-sectors` only avoids illegal sectors on the leg
+from the seller to the buyer.
+
 Using `--player` with the trades option ranks deals by profit per kilometre and automatically limits them by your ship's cargo space and available credits.
 
 The savefile can be compressed or uncompressed. It is the importing of the data that takes most of the time, once imported accessing the data is fast.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ options:
 
 `--avoid-hostile-sectors` skips trades if either station is in a hostile sector
 and searches for routes that do not pass through hostile territory from the
-player's current position to the destination.  If no such route exists the trade
-is ignored. `--avoid-illegal-sectors` only avoids illegal sectors on the leg
-from the seller to the buyer.
+player's current position to the destination. Unowned sectors are considered
+neutral, so travelling through them is always allowed. If there is no gate route
+between two stations in different sectors the trade is ignored.  `--avoid-illegal-sectors`
+only avoids illegal sectors on the leg from the seller to the buyer.
 
 Using `--player` with the trades option ranks deals by profit per kilometre and automatically limits them by your ship's cargo space and available credits.
 

--- a/x4-save-miner.py
+++ b/x4-save-miner.py
@@ -390,8 +390,6 @@ def distance_from_point_to_station(pos, sector_code, station_idx, avoid_nodes=No
         total = start_dist + d
         if total < best:
             best = total
-    if not math.isfinite(best) and avoid_nodes is None:
-        best = distance_between(pos, station['pos'])
     return best
 
 def getProfitableTrades(limit=5, max_cargo=None, use_distance=False,
@@ -440,7 +438,7 @@ def getProfitableTrades(limit=5, max_cargo=None, use_distance=False,
                         avoid_nodes
                     )
                     if not math.isfinite(dist_sell_buy):
-                        if avoid_nodes is not None:
+                        if sell['sector_code'] != buy['sector_code']:
                             continue
                         dist_sell_buy = distance_between(sell['pos'], buy['pos'])
                     origin_sector = playerLocation.get('sector_code') if origin is not None and playerLocation is not None else None
@@ -749,9 +747,10 @@ for sector in sectors:
     sectorName = sector_macros[sectorMacro] if sectorMacro in sector_macros else ""
     sector.set('sector_name', sectorName)
 
-    if sector.get('owner') in illegal_factions:
+    owner = sector.get('owner')
+    if owner and owner in illegal_factions:
         illegal_sectors.add(sectorCode)
-    if sector.get('owner') in hostile_factions:
+    if owner and owner in hostile_factions:
         hostile_sectors.add(sectorCode)
 
     updateStatsInfo(stats, sector.get('owner'), "sectors")

--- a/x4-save-miner.py
+++ b/x4-save-miner.py
@@ -396,6 +396,7 @@ def getProfitableTrades(limit=5, max_cargo=None, use_distance=False,
                         origin=None, cargo_limit=None, credits=None,
                         avoid_illegal=False, avoid_hostile=False):
     heap = []
+    counter = 0  # tie-breaker for heap items
     for ware, sellers in trade_sellers.items():
         buyers = trade_buyers.get(ware)
         if not buyers:
@@ -468,12 +469,12 @@ def getProfitableTrades(limit=5, max_cargo=None, use_distance=False,
                     'score': score
                 }
                 if len(heap) < limit:
-                    heapq.heappush(heap, (key, deal))
+                    heapq.heappush(heap, (key, counter, deal))
                 else:
                     if key > heap[0][0]:
-                        heapq.heapreplace(heap, (key, deal))
-
-    return [d for _, d in sorted(heap, key=lambda x: x[0], reverse=True)]
+                        heapq.heapreplace(heap, (key, counter, deal))
+                counter += 1
+    return [d for _, __, d in sorted(heap, key=lambda x: x[0], reverse=True)]
 
 def buildProximityInfo(oLocation, sLocation, closest, distance):
     infos = []

--- a/x4-save-miner.py
+++ b/x4-save-miner.py
@@ -390,6 +390,8 @@ def distance_from_point_to_station(pos, sector_code, station_idx, avoid_nodes=No
         total = start_dist + d
         if total < best:
             best = total
+    if not math.isfinite(best) and avoid_nodes is None:
+        best = distance_between(pos, station['pos'])
     return best
 
 def getProfitableTrades(limit=5, max_cargo=None, use_distance=False,
@@ -438,7 +440,9 @@ def getProfitableTrades(limit=5, max_cargo=None, use_distance=False,
                         avoid_nodes
                     )
                     if not math.isfinite(dist_sell_buy):
-                        continue
+                        if avoid_nodes is not None:
+                            continue
+                        dist_sell_buy = distance_between(sell['pos'], buy['pos'])
                     origin_sector = playerLocation.get('sector_code') if origin is not None and playerLocation is not None else None
                     if origin is not None:
                         avoid_origin_nodes = hostile_nodes if avoid_hostile else None


### PR DESCRIPTION
## Summary
- add `--avoid-hostile-sectors` command line option
- compute factions hostile to the player and mark hostile sectors
- skip trades involving hostile sectors and avoid hostile sectors when routing
- document new option in README

## Testing
- `python3 -m py_compile x4-save-miner.py x4-cat-miner.py`
- `python3 x4-save-miner.py -h | head`

------
https://chatgpt.com/codex/tasks/task_e_6888dea3cfd08325a48ebd8cad3fe154