### PR TITLE
Improve player-aware trade calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ options:
   -q, --quiet           Suppress warnings in interactive mode
   -i INFO, --info INFO  information level [1-3]. Default is 1 (sector only)
   -f, --factions        Display faction relative strengths
-  -t [N] [C], --trades [N] [C]  Show the top N profitable ware trades using at most C cargo (default N=5)
-  --player              Factor the player's ship location, cargo space and credits into trade ranking
+  -t [N] [C], --trades [N] [C]  Show the top N profitable ware trades using at most C cargo volume (default N=5)
+  --player              Factor the player's ship location, cargo space, and credits into trade ranking
   --distance            Rank trades by profit per kilometre
   --avoid-illegal-sectors  Avoid trades through sectors where the ware is illegal
   --avoid-hostile-sectors  Avoid trades through sectors hostile to the player
@@ -85,7 +85,7 @@ neutral, so travelling through them is always allowed. If there is no gate route
 between two stations in different sectors the trade is ignored.  `--avoid-illegal-sectors`
 only avoids illegal sectors on the leg from the seller to the buyer.
 
-Using `--player` with the trades option ranks deals by profit per kilometre and automatically limits them by your ship's cargo space and available credits.
+Using `--player` with the trades option ranks deals by profit per kilometre and automatically limits them by your ship's cargo space and available credits. Cargo limits are derived from the player's current ship hold type and ware volume.
 
 The savefile can be compressed or uncompressed. It is the importing of the data that takes most of the time, once imported accessing the data is fast.
 


### PR DESCRIPTION
## Summary
- load ware volumes and ship hold definitions to compute player cargo capacity
- detect the player's ship and cargo hold type and exit if not in a ship
- limit trade quantities by ware volume, cargo space, and available credits when using `--player`
- avoid overwriting player cargo data by later components so hold size stays accurate
- convert trade prices to credits so credit limits are applied correctly

## Testing
- `python x4-save-miner.py test_save/save_001.xml.gz -t 2 --player`
- `python - <<'PY'
import json, gzip
from lxml import etree as ET
ship_hold_sizes=json.load(open('x4-ship-holds.json'))
ware_volumes=json.load(open('x4-wares.json'))
root=ET.fromstring(gzip.open('test_save/save_001.xml.gz','rb').read())
player=root.find('.//player')
playerMoney=int(player.get('money'))
player_comp=root.find('.//component[@class="player"]')
parent=player_comp.getparent()
while parent is not None:
    if parent.tag=='component' and parent.get('class','').startswith('ship'):
        ship=parent
        break
    parent=parent.getparent()
hold_macro=None
for storage in ship.findall('.//component[@class="storage"]'):
    macro=storage.get('macro')
    if macro in ship_hold_sizes:
        hold_macro=macro
        break
hold_size=ship_hold_sizes.get(hold_macro)
seller=root.find('.//component[@code="KHN-759"]')
buyer=root.find('.//component[@code="JDS-684"]')
sa=seller.find('.//trade/offers//trade[@ware="graphene"][@seller]')
ba=buyer.find('.//trade/offers//trade[@ware="graphene"][@buyer]')
sa_price=int(sa.get('price'))/100.0
ba_price=int(ba.get('price'))/100.0
volume=ware_volumes['graphene']
qty=min(int(sa.get('amount')), int(ba.get('amount')), hold_size//volume, int(playerMoney//sa_price))
print('player credits', playerMoney)
print('seller price', sa_price, 'buyer price', ba_price)
print('hold size', hold_size, 'volume', volume, 'qty', qty)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688d4b0e8aa48325b25105dda27a1a74